### PR TITLE
Some fixes for the MPI serialization

### DIFF
--- a/examples/expect_value_test.cpp
+++ b/examples/expect_value_test.cpp
@@ -38,6 +38,8 @@ if (iqs::mpi::Environment::GetStateRank()==0) std::cout
 
 int main(int argc, char **argv)
 {
+  using Complex = ComplexPosit24<0>;
+  using BaseType = typename Complex::value_type;
   unsigned myrank=0, nprocs=1;
   iqs::mpi::Environment env(argc, argv);
   if (env.IsUsefulRank()==false) return 0;
@@ -49,13 +51,13 @@ int main(int argc, char **argv)
           fprintf(stderr, "example to be launched with a single process\n");
       exit(1);
   }
-  double expectation;
+  Complex expectation;
 
   MPIout << "------------------\n"
          << "   Single qubit   \n"
          << "------------------\n\n";
 
-  iqs::QubitRegister<ComplexDP> psi(1,"base",1);
+  iqs::QubitRegister<Complex> psi(1,"base",1);
   psi.EnableStatistics();  
   psi.ApplyHadamard(0);
 

--- a/examples/grover_4qubit.cpp
+++ b/examples/grover_4qubit.cpp
@@ -39,13 +39,14 @@ int main(int argc, char **argv)
 
    //// Grover Search EXAMPLE ////
 
+      using Complex = ComplexPosit24<2>;
       if (myid == 0) printf("\n --- GROVER EXAMPLE --- \n");
       int Ngrover = 4;
       // Create the state of a quantum register, having N qubits.
       // The state is initialized as a computational basis state (using the keyword "base")
       // corresponding to the index 0. The index corresponds to a N-bit integer in decimal
       // representation. With N qubits there are 2^N indices, from 0 to 2^{N-1}.
-      iqs::QubitRegister<ComplexDP> psig(Ngrover, "base", 0);
+      iqs::QubitRegister<Complex> psig(Ngrover, "base", 0);
 	  
       psig.Print("Initial State =");
 

--- a/include/mpi_utils.hpp
+++ b/include/mpi_utils.hpp
@@ -4,11 +4,13 @@
 #ifdef INTELQS_HAS_MPI
 
 /////////////////////////////////////////////////////////////////////////////////////////
-// All methods involve MPI types in the arguments. Only available with MPI enabled.
-// However there are two implementation depending on whether BIGMPI is used or not.
+// All methods involve MPI types in the arguments. Only available with MPI
+// enabled. However there are two implementation depending on whether BIGMPI is
+// used or not.
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #include <complex>
+#include <climits>
 #include <mpi.h>
 
 #include "utils.hpp"
@@ -23,28 +25,58 @@ namespace iqs {
 
 namespace mpi {
 
-template<typename Posit>
-using Bitblock = decltype(Posit().get());
+template <typename Posit> using Bitblock = decltype(Posit().get());
 
-template <typename Posit> struct ComplexBitblock {
+template <typename Posit> struct __attribute__((__packed__)) ComplexBitblock {
   using bits = Bitblock<Posit>;
 
-  ComplexBitblock(std::complex<Posit> p)
-      : real(p.real().get()), imag(p.imag().get()) {}
+  static constexpr size_t nbits = Posit::nbits;
+  static constexpr size_t nbytes = nbits / CHAR_BIT;
+
+  ComplexBitblock(std::complex<Posit> p) {
+    buf_from_bits(p.real().get(), real);
+    buf_from_bits(p.imag().get(), imag);
+  }
 
   ComplexBitblock() = default;
 
-  bits real;
-  bits imag;
+  uint8_t real[nbytes];
+  uint8_t imag[nbytes];
 
   std::complex<Posit> to_posit() const {
     Posit real_posit;
-    real_posit.setBitblock(real);
+    real_posit.setBitblock(bits_from_buf(real));
     Posit imag_posit;
-    imag_posit.setBitblock(imag);
+    imag_posit.setBitblock(bits_from_buf(imag));
     return std::complex(real_posit, imag_posit);
   }
+
+  bits bits_from_buf(const uint8_t arr[nbits]) const {
+    unsigned long val =
+        ((((unsigned long)arr[0]) << 16) | (((unsigned long)arr[1]) << 8) |
+         (unsigned long)arr[2]);
+    // Unfortunately, universal does not expose Bitblock::Bitblock(unsigned long),
+    // so we have to live with this hack
+    std::bitset<nbits> newval{val};
+    bits retval;
+    auto& bitset = retval.reset();
+    bitset = newval;
+    return retval;
+  }
+
+  void buf_from_bits(const bits set, uint8_t *out) const {
+    auto val = set.to_ulong();
+
+    uint8_t *val_ptr = reinterpret_cast<uint8_t *>(&val);
+    for (int i = 0; i < 3; i++) {
+      std::memcpy(out + 2 - i, val_ptr + i, 1);
+    }
+  }
 };
+
+// B-)
+// Thats just 6 byte
+static_assert(sizeof(ComplexBitblock<IqsPosit24<2>>) == 2 * IqsPosit24<2>::nbits / CHAR_BIT);
 
 extern MPI_Datatype mpi_datatype_handle_posit24_es0;
 extern MPI_Datatype mpi_datatype_handle_posit24_es1;
@@ -67,8 +99,8 @@ posit_buffer_to_byte_buffer(const ComplexPosit24<es> *posit_buffer,
 
   std::vector<ComplexBitblock<IqsPosit24<es>>> byte_buffer;
 
-  for(auto in = posit_buffer; in < posit_buffer + posit_count; in++) {
-    auto& num = *in;
+  for (auto in = posit_buffer; in < posit_buffer + posit_count; in++) {
+    auto &num = *in;
     byte_buffer.push_back(num);
   }
 
@@ -76,74 +108,78 @@ posit_buffer_to_byte_buffer(const ComplexPosit24<es> *posit_buffer,
 }
 
 template <size_t es>
-void byte_buffer_to_posit_buffer(const std::vector<ComplexBitblock<IqsPosit24<es>>> &byte_buffer, ComplexPosit24<es> *posit_buffer, size_t) {
+void byte_buffer_to_posit_buffer(
+    const std::vector<ComplexBitblock<IqsPosit24<es>>> &byte_buffer,
+    ComplexPosit24<es> *posit_buffer, size_t) {
   size_t i = 0;
-  for(auto &bs : byte_buffer) {
+  for (auto &bs : byte_buffer) {
     posit_buffer[i++] = bs.to_posit();
   }
 }
 
 template <typename Posit, typename F>
-static void posit_reduce_bitblock(Bitblock<Posit> *in, Bitblock<Posit> *in_out, const F& func) {
+static void posit_reduce_bitblock(Bitblock<Posit> *in, Bitblock<Posit> *in_out,
+                                  const F &func) {
   Posit in_posit = Posit().setBitblock((const Bitblock<Posit>)*in);
   Posit in_out_posit = Posit().setBitblock((const Bitblock<Posit>)*in_out);
 
-  Posit result = func(in_posit, in_out_posit);  //,  > in_out_posit ? in_posit : in_out_posit;
+  Posit result = func(
+      in_posit, in_out_posit); //,  > in_out_posit ? in_posit : in_out_posit;
   *in_out = result.get();
 }
 
-static void mpi_sum_posit24(void *in, void *in_out, int *len, MPI_Datatype *datatype) {
+static void mpi_sum_posit24(void *in, void *in_out, int *len,
+                            MPI_Datatype *datatype) {
   if (*len != 1) {
     throw std::runtime_error("mpi_sum_posit24: len > 1 not implemented.");
   }
 
-  auto reduce = [](const auto& l, const auto& r) {
-    return l + r;
-  };
-  
+  auto reduce = [](const auto &l, const auto &r) { return l + r; };
+
   constexpr size_t nbits = 24;
   if (*datatype == mpi_datatype_handle_posit24_es0) {
     using Posit = sw::universal::posit<nbits, 0>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else if (*datatype == mpi_datatype_handle_posit24_es1) {
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else if (*datatype == mpi_datatype_handle_posit24_es1) {
     using Posit = sw::universal::posit<nbits, 1>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else if (*datatype == mpi_datatype_handle_posit24_es2) {
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else if (*datatype == mpi_datatype_handle_posit24_es2) {
     using Posit = sw::universal::posit<nbits, 2>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else {
-    std::cout << "Error: MPI datatype not supported: " << *datatype << std::endl;
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else {
+    std::cout << "Error: MPI datatype not supported: " << *datatype
+              << std::endl;
     throw std::runtime_error("Invalid datatype for posit24 addition.");
   }
 }
 
-static void mpi_max_posit24(void *in, void *in_out, int *len, MPI_Datatype *datatype) {
+static void mpi_max_posit24(void *in, void *in_out, int *len,
+                            MPI_Datatype *datatype) {
   if (*len != 1) {
     throw std::runtime_error("mpi_max_posit24: len > 1 not implemented.");
   }
 
-  auto reduce = [](const auto& l, const auto& r) {
-    return max(l, r);
-  };
+  auto reduce = [](const auto &l, const auto &r) { return max(l, r); };
 
   constexpr size_t nbits = 24;
   if (*datatype == mpi_datatype_handle_posit24_es0) {
     using Posit = sw::universal::posit<nbits, 0>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else if (*datatype == mpi_datatype_handle_posit24_es1) {
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else if (*datatype == mpi_datatype_handle_posit24_es1) {
     using Posit = sw::universal::posit<nbits, 1>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else if (*datatype == mpi_datatype_handle_posit24_es2) {
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else if (*datatype == mpi_datatype_handle_posit24_es2) {
     using Posit = sw::universal::posit<nbits, 2>;
-    posit_reduce_bitblock<Posit>((Bitblock<Posit>*)in, (Bitblock<Posit>*)in_out, reduce);
-  }
-  else {
-    std::cout << "Error: MPI datatype not supported: " << *datatype << std::endl;
+    posit_reduce_bitblock<Posit>((Bitblock<Posit> *)in,
+                                 (Bitblock<Posit> *)in_out, reduce);
+  } else {
+    std::cout << "Error: MPI datatype not supported: " << *datatype
+              << std::endl;
     throw std::runtime_error("Invalid datatype for posit24 max.");
   }
 }
@@ -152,88 +188,86 @@ static void mpi_max_posit24(void *in, void *in_out, int *len, MPI_Datatype *data
 // Definitions without BigMPI
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static int MPI_Allreduce_x(float *sendbuf, float *recvbuf, int count,
-                           MPI_Op op, MPI_Comm comm)
-{
-  return MPI_Allreduce((void*)sendbuf, (void *)recvbuf, count, MPI_FLOAT, op, comm);
+static int MPI_Allreduce_x(float *sendbuf, float *recvbuf, int count, MPI_Op op,
+                           MPI_Comm comm) {
+  return MPI_Allreduce((void *)sendbuf, (void *)recvbuf, count, MPI_FLOAT, op,
+                       comm);
 }
 
 static int MPI_Allreduce_x(double *sendbuf, double *recvbuf, int count,
-                           MPI_Op op, MPI_Comm comm)
-{
-  return MPI_Allreduce((void*)sendbuf, (void *)recvbuf, count, MPI_DOUBLE, op, comm);
+                           MPI_Op op, MPI_Comm comm) {
+  return MPI_Allreduce((void *)sendbuf, (void *)recvbuf, count, MPI_DOUBLE, op,
+                       comm);
 }
 
 template <size_t es>
-static int MPI_Allreduce_x(IqsPosit24<es> *sendbuf, IqsPosit24<es> *recvbuf, int count, MPI_Op op, MPI_Comm comm)
-{
+static int MPI_Allreduce_x(IqsPosit24<es> *sendbuf, IqsPosit24<es> *recvbuf,
+                           int count, MPI_Op op, MPI_Comm comm) {
   MPI_Op posit_op;
   MPI_Datatype posit_datatype;
 
   if (op == MPI_SUM) {
     posit_op = mpi_op_handle_sum_posit24;
-  }
-  else if (op == MPI_MAX) {
+  } else if (op == MPI_MAX) {
     posit_op = mpi_op_handle_max_posit24;
-  }
-  else {
-    std::cout << "MPI_Allreduce_x: Unsupported operation for posits: " << op << std::endl;
+  } else {
+    std::cout << "MPI_Allreduce_x: Unsupported operation for posits: " << op
+              << std::endl;
     throw std::runtime_error("MPI_Allreduce_x: Unsupported MPI_Op");
   }
 
   if (es == 0) {
     posit_datatype = mpi_datatype_handle_posit24_es0;
-  }
-  else if (es == 1) {
+  } else if (es == 1) {
     posit_datatype = mpi_datatype_handle_posit24_es1;
-  }
-  else if (es == 2) {
+  } else if (es == 2) {
     posit_datatype = mpi_datatype_handle_posit24_es2;
-  }
-  else {
-    std::cout << "MPI_Allreduce_x: Unsupported es for posits: " << es << std::endl;
+  } else {
+    std::cout << "MPI_Allreduce_x: Unsupported es for posits: " << es
+              << std::endl;
     throw std::runtime_error("MPI_Allreduce_x: Unsupported es");
   }
 
-  return MPI_Allreduce((void*)sendbuf, (void *)recvbuf, count, posit_datatype, posit_op, comm);
+  return MPI_Allreduce((void *)sendbuf, (void *)recvbuf, count, posit_datatype,
+                       posit_op, comm);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static
-int MPI_Sendrecv_x(ComplexSP *sendbuf, size_t sendcount, size_t dest, size_t sendtag,
-                   ComplexSP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
-                   MPI_Comm comm, MPI_Status *status)
-{
-  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX, dest, sendtag,
-                      (void *)recvbuf, recvcount, MPI_CXX_FLOAT_COMPLEX, source, recvtag,
-                       comm, status);
+static int MPI_Sendrecv_x(ComplexSP *sendbuf, size_t sendcount, size_t dest,
+                          size_t sendtag, ComplexSP *recvbuf, size_t recvcount,
+                          size_t source, size_t recvtag, MPI_Comm comm,
+                          MPI_Status *status) {
+  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX, dest,
+                      sendtag, (void *)recvbuf, recvcount,
+                      MPI_CXX_FLOAT_COMPLEX, source, recvtag, comm, status);
 }
 
-static
-int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest, size_t sendtag,
-                   ComplexDP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
-                   MPI_Comm comm, MPI_Status *status)
-{
-  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX, dest, sendtag,
-                      (void *)recvbuf, recvcount, MPI_CXX_DOUBLE_COMPLEX, source, recvtag,
-                      comm, status);
+static int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest,
+                          size_t sendtag, ComplexDP *recvbuf, size_t recvcount,
+                          size_t source, size_t recvtag, MPI_Comm comm,
+                          MPI_Status *status) {
+  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX, dest,
+                      sendtag, (void *)recvbuf, recvcount,
+                      MPI_CXX_DOUBLE_COMPLEX, source, recvtag, comm, status);
 }
 
-template<size_t es>
-static int MPI_Sendrecv_x(ComplexPosit24<es> *sendbuf, size_t sendcount, size_t dest, size_t sendtag,
-                          ComplexPosit24<es> *recvbuf, size_t recvcount, size_t source, size_t recvtag,
-                          MPI_Comm comm, MPI_Status *status)
-{
+template <size_t es>
+static int MPI_Sendrecv_x(ComplexPosit24<es> *sendbuf, size_t sendcount,
+                          size_t dest, size_t sendtag,
+                          ComplexPosit24<es> *recvbuf, size_t recvcount,
+                          size_t source, size_t recvtag, MPI_Comm comm,
+                          MPI_Status *status) {
   std::vector<ComplexBitblock<IqsPosit24<es>>> byte_recvbuf(recvcount);
 
   auto byte_sendbuf = posit_buffer_to_byte_buffer<es>(sendbuf, sendcount);
 
   auto scale = sizeof(ComplexBitblock<IqsPosit24<es>>);
-  int ret_val = MPI_Sendrecv(byte_sendbuf.data(), sendcount * scale, MPI_BYTE, dest, sendtag,
-                             byte_recvbuf.data(), recvcount * scale, MPI_BYTE, source, recvtag,
-                             comm, status);
-  
+  int ret_val =
+      MPI_Sendrecv(byte_sendbuf.data(), sendcount * scale, MPI_BYTE, dest,
+                   sendtag, byte_recvbuf.data(), recvcount * scale, MPI_BYTE,
+                   source, recvtag, comm, status);
+
   /* std::transform(); */
   byte_buffer_to_posit_buffer<es>(byte_recvbuf, recvbuf, recvcount);
 
@@ -242,26 +276,23 @@ static int MPI_Sendrecv_x(ComplexPosit24<es> *sendbuf, size_t sendcount, size_t 
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static int MPI_Bcast_x(ComplexSP *data, int root, MPI_Comm comm)
-{
-  return MPI_Bcast((void*)data, 1, MPI_CXX_FLOAT_COMPLEX, root, comm);
+static int MPI_Bcast_x(ComplexSP *data, int root, MPI_Comm comm) {
+  return MPI_Bcast((void *)data, 1, MPI_CXX_FLOAT_COMPLEX, root, comm);
 }
 
-static int MPI_Bcast_x(ComplexDP *data, int root, MPI_Comm comm)
-{
-  return MPI_Bcast((void*)data, 1, MPI_CXX_DOUBLE_COMPLEX, root, comm);
+static int MPI_Bcast_x(ComplexDP *data, int root, MPI_Comm comm) {
+  return MPI_Bcast((void *)data, 1, MPI_CXX_DOUBLE_COMPLEX, root, comm);
 }
 
-template<size_t es>
-static int MPI_Bcast_x(ComplexPosit24<es> *data, int root, MPI_Comm comm)
-{
+template <size_t es>
+static int MPI_Bcast_x(ComplexPosit24<es> *data, int root, MPI_Comm comm) {
 
   auto byte_sendbuf = posit_buffer_to_byte_buffer<es>(data, 1);
 
   size_t scale = sizeof(ComplexBitblock<IqsPosit24<es>>);
 
   int ret_val = MPI_Bcast(byte_sendbuf.data(), scale, MPI_BYTE, root, comm);
-  
+
   byte_buffer_to_posit_buffer<es>(byte_sendbuf, data, 1);
 
   return ret_val;
@@ -273,67 +304,63 @@ static int MPI_Bcast_x(ComplexPosit24<es> *data, int root, MPI_Comm comm)
 // Definitions with BigMPI
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static int MPI_Allreduce_x(float *sendbuf, float *recvbuf, int count,
-                           MPI_Op op, MPI_Comm comm)
-{
-  return MPIX_Allreduce_x((void*)sendbuf, (void *)recvbuf, count, MPI_FLOAT, op, comm);
+static int MPI_Allreduce_x(float *sendbuf, float *recvbuf, int count, MPI_Op op,
+                           MPI_Comm comm) {
+  return MPIX_Allreduce_x((void *)sendbuf, (void *)recvbuf, count, MPI_FLOAT,
+                          op, comm);
 }
 
 static int MPI_Allreduce_x(double *sendbuf, double *recvbuf, int count,
-                           MPI_Op op, MPI_Comm comm)
-{
-  return MPIX_Allreduce_x((void*)sendbuf, (void *)recvbuf, count, MPI_DOUBLE, op, comm);
+                           MPI_Op op, MPI_Comm comm) {
+  return MPIX_Allreduce_x((void *)sendbuf, (void *)recvbuf, count, MPI_DOUBLE,
+                          op, comm);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static
- int MPI_Sendrecv_x(ComplexSP *sendbuf, size_t sendcount, size_t dest, size_t sendtag,
-                   ComplexSP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
-                   MPI_Comm comm, MPI_Status *status)
-{
-  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX, dest, sendtag,
-                         (void *)recvbuf, recvcount, MPI_CXX_FLOAT_COMPLEX, source, recvtag,
-                         comm, status);
+static int MPI_Sendrecv_x(ComplexSP *sendbuf, size_t sendcount, size_t dest,
+                          size_t sendtag, ComplexSP *recvbuf, size_t recvcount,
+                          size_t source, size_t recvtag, MPI_Comm comm,
+                          MPI_Status *status) {
+  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX,
+                         dest, sendtag, (void *)recvbuf, recvcount,
+                         MPI_CXX_FLOAT_COMPLEX, source, recvtag, comm, status);
 }
 
-static
-int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest, size_t sendtag,
-                   ComplexDP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
-                   MPI_Comm comm, MPI_Status *status)
-{
-  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX, dest, sendtag,
-                         (void *)recvbuf, recvcount, MPI_CXX_DOUBLE_COMPLEX, source, recvtag,
-                         comm, status);
+static int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest,
+                          size_t sendtag, ComplexDP *recvbuf, size_t recvcount,
+                          size_t source, size_t recvtag, MPI_Comm comm,
+                          MPI_Status *status) {
+  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX,
+                         dest, sendtag, (void *)recvbuf, recvcount,
+                         MPI_CXX_DOUBLE_COMPLEX, source, recvtag, comm, status);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-static int MPI_Bcast_x(ComplexSP *data, int root, MPI_Comm comm)
-{
- // Not sure of how it is defined with BigMPI.
- assert(0);
+static int MPI_Bcast_x(ComplexSP *data, int root, MPI_Comm comm) {
+  // Not sure of how it is defined with BigMPI.
+  assert(0);
 }
 
 //
 
-static int MPI_Bcast_x(ComplexDP *data, int root, MPI_Comm comm)
-{
- // Not sure of how it is defined with BigMPI.
- assert(0);
+static int MPI_Bcast_x(ComplexDP *data, int root, MPI_Comm comm) {
+  // Not sure of how it is defined with BigMPI.
+  assert(0);
 }
 
-#endif //BIGMPI
+#endif // BIGMPI
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-}	// end namespace mpi
-}	// end namespace iqs
+} // end namespace mpi
+} // end namespace iqs
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#endif	// INTELQS_HAS_MPI
+#endif // INTELQS_HAS_MPI
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#endif	// header guard IQS_MPI_UTILS_HPP
+#endif // header guard IQS_MPI_UTILS_HPP

--- a/src/qureg_utils.cpp
+++ b/src/qureg_utils.cpp
@@ -277,9 +277,11 @@ std::string PrintVector(Type *state, std::size_t size, std::size_t num_elements,
     // std::string bin = dec2bin(myrank * size + i, num_qubits, false);
     std::string bin = permutation->data2program((std::size_t)my_data_rank * size + i);
     char s[4096];
+    double real = double(state[i].real());
+    double im = double(state[i].imag());
     sprintf(s, "\t%-13.8lf + i * %-13.8lf   %% |%s> p=%lf\n",
-            std::real(state[i]), std::imag(state[i]),
-            (const char *)bin.c_str(), std::norm(state[i]) );
+            real, im,
+            (const char *)bin.c_str(), double(norm(state[i])) );
     str = str + s;
     cumulative_probability += std::norm(state[i]);
   }

--- a/src/qureg_utils.cpp
+++ b/src/qureg_utils.cpp
@@ -199,7 +199,7 @@ typename QubitRegister<Type>::BaseType QubitRegister<Type>::ComputeNorm()
 #pragma omp parallel for reduction(+ : local_normsq)
   for(std::size_t i = 0; i < lcl; i++)
   {
-     local_normsq += std::norm(state[i]);
+     local_normsq += norm(state[i]);
   }
 
   BaseType global_normsq;
@@ -266,9 +266,9 @@ Type QubitRegister<Type>::ComputeOverlap( QubitRegister<Type> &psi)
 /// index of the computational state and corresponding amplitude.
 /// Partial sum of |amplitude|^2 is computed.
 //------------------------------------------------------------------------------
-template <class Type, class BaseType>
+template <class Type>
 std::string PrintVector(Type *state, std::size_t size, std::size_t num_elements,
-                        BaseType &cumulative_probability,
+                        double &cumulative_probability,
                         Permutation *permutation,
                         int my_data_rank)
 {
@@ -283,7 +283,7 @@ std::string PrintVector(Type *state, std::size_t size, std::size_t num_elements,
             real, im,
             (const char *)bin.c_str(), double(norm(state[i])) );
     str = str + s;
-    cumulative_probability += std::norm(state[i]);
+    cumulative_probability += double(norm(state[i]));
   }
   return std::string(str);
 }
@@ -301,7 +301,7 @@ template <class Type>
 void QubitRegister<Type>::Print(std::string x, std::vector<std::size_t> qubits)
 {
   TODO(Second argument of Print() is not used!)
-  BaseType cumulative_probability = 0;
+  double cumulative_probability = 0;
 
   int my_rank = iqs::mpi::Environment::GetStateRank();
   int nprocs = iqs::mpi::Environment::GetStateSize();
@@ -316,7 +316,7 @@ void QubitRegister<Type>::Print(std::string x, std::vector<std::size_t> qubits)
       // print permutation
       assert(qubit_permutation);
       printf("qubit permutation: %s\n", qubit_permutation->GetMapStr().c_str());
-      std::string s = PrintVector<Type, BaseType>(state, LocalSize(), num_qubits,
+      std::string s = PrintVector<Type>(state, LocalSize(), num_qubits,
                                                   cumulative_probability, qubit_permutation, my_rank);
       printf("%s=[\n", (const char *)x.c_str());
       printf("%s", (const char *)s.c_str());
@@ -357,7 +357,7 @@ void QubitRegister<Type>::Print(std::string x, std::vector<std::size_t> qubits)
 #endif
   }
 
-  BaseType glb_cumulative_probability;
+  double glb_cumulative_probability;
 #ifdef INTELQS_HAS_MPI
   MPI_Reduce(&cumulative_probability, &glb_cumulative_probability, 1, MPI_DOUBLE, MPI_SUM, 0, comm);
 #else


### PR DESCRIPTION
- Serializes a `std::complex<Posit<N, es>>` to `2 * N / 8` bytes
- Fixed my very stupid typo
- Grover works now, QFT still suffers from the RNG problem. Prooobably has to do with the reduction in `ComputeNorm`.
- Work on `MPI_BYTE` where possible